### PR TITLE
Add unit tests for expanding by multiple errors in one call

### DIFF
--- a/test/StandardError.test.js
+++ b/test/StandardError.test.js
@@ -30,7 +30,7 @@ test.each`
 	                                                                                              title: 'Missing Title',
 	                                                                                              message: 'Missing Message'}}
 	${607} | ${607}       | ${'application'} | ${'Test 10'} | ${'This is a test'} | ${true}  | ${{}}
-`('Expand StandardError object', ({key, code, domain, title, message, passed, errors}) => {
+`(`Expanding StandardError object does output expected verification success and error messages`, ({key, code, domain, title, message, passed, errors}) => {
 	// Setup
 	var data = {};
 	data[key] = {code: code, domain: domain, title: title, message: message};
@@ -48,4 +48,64 @@ test.each`
 			}
 		}
 	}
+});
+
+test('Expanding StandardError object with blob of multiple new errors fails malformed errors individually', async() => {
+	// Setup
+	var data = {
+		500: {code: 500, domain: 'application', title: 'Test 1', message: '500 is already taken by the default StandardError object'},
+		801: {code: 801, domain: undefined, title: 'Test 2', message: 'Error with undefined domain'},
+		802: {code: 802, domain: 'application', title: undefined, message: 'Error with undefined title'},
+		803: {code: 803, domain: 'application', title: 'Test 4', message: undefined},
+		804: {code: 804, domain: 'application', title: 'Test 5', message: 'Well formed error, will be added successfully'}
+	};
+
+	// Execute
+	var verification = StandardError.expand(data);
+
+	// Test
+	expect(verification.passed).toEqual(false);
+
+	// Failed 500 and did not overwrite existing 500 error
+	expect(verification[500].passed).toEqual(false);
+	expect(verification[500].code).toEqual('Code already in use');
+	expect(StandardError[500]).not.toEqual(data[500]);
+
+	// Failed 801 error
+	expect(verification[801].passed).toEqual(false);
+	expect(verification[801].domain).toEqual('Missing Domain');
+	expect(StandardError[801]).toEqual(undefined);
+
+	// Failed 802 error
+	expect(verification[802].passed).toEqual(false);
+	expect(verification[802].title).toEqual('Missing Title');
+	expect(StandardError[802]).toEqual(undefined);
+
+	// Failed 803 error
+	expect(verification[803].passed).toEqual(false);
+	expect(verification[803].message).toEqual('Missing Message');
+	expect(StandardError[803]).toEqual(undefined);
+
+	// Passed 804 error
+	expect(StandardError[804]).toEqual(data[804]);
+});
+
+test('Can expand StandardError object with blob of multiple new errors with one call', async() => {
+	// Setup
+	var data = {
+		700: {code: 700, domain: 'application', title: 'Test 1', message: 'This is a test error message'},
+		701: {code: 701, domain: 'application', title: 'Test 2', message: 'This is a test error message'},
+		702: {code: 702, domain: 'application', title: 'Test 3', message: 'This is a test error message'},
+		703: {code: 703, domain: 'application', title: 'Test 4', message: 'This is a test error message'}
+	};
+
+	// Execute
+	var verification = StandardError.expand(data);
+
+	// Test
+	expect(verification.passed).toEqual(true);
+	expect(StandardError[700]).toEqual(data[700]);
+	expect(StandardError[701]).toEqual(data[701]);
+	expect(StandardError[702]).toEqual(data[702]);
+	expect(StandardError[703]).toEqual(data[703]);
 });


### PR DESCRIPTION
- Expanded unit tests to check verification process for blobs of multiple new errors being added at once