### PR TITLE
Tweaks for readability, change `list` to `show`, add HttpCodes.js

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+node_modules/
+**/.DS_Store
+.circleci/

--- a/package.json
+++ b/package.json
@@ -18,5 +18,6 @@
   "homepage": "https://github.com/unplgtc/StandardError#readme",
   "devDependencies": {
     "jest": "^23.4.2"
-  }
+  },
+  "dependencies": {}
 }

--- a/src/HttpCodes.js
+++ b/src/HttpCodes.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const HttpCodes = {
+	200: {code: 200, domain: 'http', title: 'OK', message: 'Request successful'},
+
+	201: {code: 201, domain: 'http', title: 'Created', message: 'Request successful, resource created'},
+
+	202: {code: 202, domain: 'http', title: 'Accepted', message: 'The request has been accepted for processing'},
+
+	204: {code: 204, domain: 'http', title: 'No Content', message: 'Request successful, but no content returned'},
+
+	400: {code: 400, domain: 'http', title: 'Bad Request', message: 'The server cannot or will not process the request'},
+
+	401: {code: 401, domain: 'http', title: 'Unauthorized', message: 'Authentication required'},
+
+	403: {code: 403, domain: 'http', title: 'Forbidden', message: 'Valid request, but the requested action is forbidden'},
+
+	404: {code: 404, domain: 'http', title: 'Not Found', message: 'The requested resource could not be found'},
+
+	405: {code: 405, domain: 'http', title: 'Method Not Allowed', message: 'The requested method is not supported for the requested resource'},
+
+	406: {code: 406, domain: 'http', title: 'Not Acceptable', message: 'The requested resource is capable of generating only content not acceptable according to the Accept headers sent in the request'},
+
+	407: {code: 407, domain: 'http', title: 'Proxy Authentication Required', message: 'The client must first authenticate itself with the proxy'},
+
+	408: {code: 408, domain: 'http', title: 'Request Timeout', message: 'The client did not produce a request within the time that the server was prepared to wait'},
+
+	409: {code: 409, domain: 'http', title: 'Conflict', message: 'The request could not be processed because of a conflict in the current state of the resource'},
+
+	410: {code: 410, domain: 'http', title: 'Gone', message: 'The resource requested is no longer available and will not be available again'},
+
+	418: {code: 418, domain: 'http', title: 'I\'m a Teapot', message: 'The requested entity body is short and stout'},
+
+	429: {code: 429, domain: 'http', title: 'Too Many Request', message: 'Too many requests sent in a given amount of time'},
+
+	500: {code: 500, domain: 'http', title: 'Internal Error', message: 'Unexpected condition was encounterd'},
+
+	501: {code: 501, domain: 'http', title: 'Not Implemented', message: 'Request method unsupported or unfulfillable'},
+
+	502: {code: 502, domain: 'http', title: 'Bad Gateway', message: 'Invalid response received from upstream server'},
+
+	503: {code: 503, domain: 'http', title: 'Service Unavailable', message: 'The server is currently unavailable'}
+}
+
+module.exports = HttpCodes;

--- a/test/StandardError.test.js
+++ b/test/StandardError.test.js
@@ -14,12 +14,12 @@ const StandardError = require('./../src/StandardError');
  *         *
  * * * * * */
 
- test('Can list all errors as Object with codes as keys', async() => {
+ test('Can output all errors as Object with codes as keys', async() => {
 	// Execute
-	var list = StandardError.list();
+	var map = StandardError.show();
 
 	// Test
-	expect(list[500]).toEqual(StandardError[500]);
+	expect(map[500]).toEqual(StandardError[500]);
 });
 
 test('Can list all error keys', async() => {
@@ -30,7 +30,7 @@ test('Can list all error keys', async() => {
 	expect(list).toContain('500');
 });
 
-test('Can list all errors as list of Objects', async() => {
+test('Can list all error Objects', async() => {
 	// Execute
 	var list = StandardError.listErrors();
 
@@ -132,13 +132,13 @@ test('Can expand StandardError object with blob of multiple new errors with one 
 	expect(StandardError[803]).toEqual(data.filter(error => error.code == 803)[0]);
 });
 
-test('Can list all errors by domain as Object with codes as keys', async() => {
+test('Can output all errors by domain as Object with codes as keys', async() => {
 	// Execute
-	var list = StandardError.list('application');
+	var map = StandardError.show('application');
 
 	// Test
-	expect(list[500]).toEqual(undefined);
-	expect(list[600]).toEqual(StandardError[600]);
+	expect(map[500]).toEqual(undefined);
+	expect(map[600]).toEqual(StandardError[600]);
 });
 
 test('Can list all error keys by domain', async() => {


### PR DESCRIPTION
- Changed the `list` function to `show` because it returns a map rather than an array. `listKeys` and `listErrors` both return arrays so it's inconsistent to have `list` return the full error map
- Tweaked the `show`, `listKeys`, and `listErrors` functions to make the ternaries a bit more readable
- HttpErrors didn't belong in the same file as the StandardError object. Moved it to its own file and changed its title to HttpCodes so that it could have `200` codes added. This is a bit strange for an Object called "StandardError" but I think its more strange to support 400-level HTTP codes in something that doesn't support 200s. People can use it however they want so they don't have to use the included HTTP codes if they have a better way of handling those
- Added .npmignore file to prepare for publishing to npm