### PR TITLE
Changed stored errors to functions that return instances with additional details

### DIFF
--- a/src/HttpCodes.js
+++ b/src/HttpCodes.js
@@ -1,45 +1,45 @@
 'use strict';
 
-const HttpCodes = {
-	200: {code: 200, domain: 'http', title: 'OK', message: 'Request successful'},
+const HttpCodes = [
+	{code: 'http_200', domain: 'http', title: 'OK', message: 'Request successful'},
 
-	201: {code: 201, domain: 'http', title: 'Created', message: 'Request successful, resource created'},
+	{code: 'http_201', domain: 'http', title: 'Created', message: 'Request successful, resource created'},
 
-	202: {code: 202, domain: 'http', title: 'Accepted', message: 'The request has been accepted for processing'},
+	{code: 'http_202', domain: 'http', title: 'Accepted', message: 'The request has been accepted for processing'},
 
-	204: {code: 204, domain: 'http', title: 'No Content', message: 'Request successful, but no content returned'},
+	{code: 'http_204', domain: 'http', title: 'No Content', message: 'Request successful, but no content returned'},
 
-	400: {code: 400, domain: 'http', title: 'Bad Request', message: 'The server cannot or will not process the request'},
+	{code: 'http_400', domain: 'http', title: 'Bad Request', message: 'The server cannot or will not process the request'},
 
-	401: {code: 401, domain: 'http', title: 'Unauthorized', message: 'Authentication required'},
+	{code: 'http_401', domain: 'http', title: 'Unauthorized', message: 'Authentication required'},
 
-	403: {code: 403, domain: 'http', title: 'Forbidden', message: 'Valid request, but the requested action is forbidden'},
+	{code: 'http_403', domain: 'http', title: 'Forbidden', message: 'Valid request, but the requested action is forbidden'},
 
-	404: {code: 404, domain: 'http', title: 'Not Found', message: 'The requested resource could not be found'},
+	{code: 'http_404', domain: 'http', title: 'Not Found', message: 'The requested resource could not be found'},
 
-	405: {code: 405, domain: 'http', title: 'Method Not Allowed', message: 'The requested method is not supported for the requested resource'},
+	{code: 'http_405', domain: 'http', title: 'Method Not Allowed', message: 'The requested method is not supported for the requested resource'},
 
-	406: {code: 406, domain: 'http', title: 'Not Acceptable', message: 'The requested resource is capable of generating only content not acceptable according to the Accept headers sent in the request'},
+	{code: 'http_406', domain: 'http', title: 'Not Acceptable', message: 'The requested resource is capable of generating only content not acceptable according to the Accept headers sent in the request'},
 
-	407: {code: 407, domain: 'http', title: 'Proxy Authentication Required', message: 'The client must first authenticate itself with the proxy'},
+	{code: 'http_407', domain: 'http', title: 'Proxy Authentication Required', message: 'The client must first authenticate itself with the proxy'},
 
-	408: {code: 408, domain: 'http', title: 'Request Timeout', message: 'The client did not produce a request within the time that the server was prepared to wait'},
+	{code: 'http_408', domain: 'http', title: 'Request Timeout', message: 'The client did not produce a request within the time that the server was prepared to wait'},
 
-	409: {code: 409, domain: 'http', title: 'Conflict', message: 'The request could not be processed because of a conflict in the current state of the resource'},
+	{code: 'http_409', domain: 'http', title: 'Conflict', message: 'The request could not be processed because of a conflict in the current state of the resource'},
 
-	410: {code: 410, domain: 'http', title: 'Gone', message: 'The resource requested is no longer available and will not be available again'},
+	{code: 'http_410', domain: 'http', title: 'Gone', message: 'The resource requested is no longer available and will not be available again'},
 
-	418: {code: 418, domain: 'http', title: 'I\'m a Teapot', message: 'The requested entity body is short and stout'},
+	{code: 'http_418', domain: 'http', title: 'I\'m a Teapot', message: 'The requested entity body is short and stout'},
 
-	429: {code: 429, domain: 'http', title: 'Too Many Request', message: 'Too many requests sent in a given amount of time'},
+	{code: 'http_429', domain: 'http', title: 'Too Many Request', message: 'Too many requests sent in a given amount of time'},
 
-	500: {code: 500, domain: 'http', title: 'Internal Error', message: 'Unexpected condition was encountered'},
+	{code: 'http_500', domain: 'http', title: 'Internal Error', message: 'Unexpected condition was encountered'},
 
-	501: {code: 501, domain: 'http', title: 'Not Implemented', message: 'Request method unsupported or unfulfillable'},
+	{code: 'http_501', domain: 'http', title: 'Not Implemented', message: 'Request method unsupported or unfulfillable'},
 
-	502: {code: 502, domain: 'http', title: 'Bad Gateway', message: 'Invalid response received from upstream server'},
+	{code: 'http_502', domain: 'http', title: 'Bad Gateway', message: 'Invalid response received from upstream server'},
 
-	503: {code: 503, domain: 'http', title: 'Service Unavailable', message: 'The server is currently unavailable'}
-}
+	{code: 'http_503', domain: 'http', title: 'Service Unavailable', message: 'The server is currently unavailable'}
+];
 
 module.exports = HttpCodes;

--- a/test/StandardError.test.js
+++ b/test/StandardError.test.js
@@ -19,7 +19,7 @@ test('Can output all errors as Object with codes as keys', async() => {
 	var map = StandardError.show();
 
 	// Test
-	expect(map[500]).toEqual(StandardError[500]);
+	expect(map['http_500']).toEqual(StandardError['http_500']());
 });
 
 test('Can list all error keys', async() => {
@@ -27,7 +27,7 @@ test('Can list all error keys', async() => {
 	var list = StandardError.listKeys();
 
 	// Test
-	expect(list).toContain('500');
+	expect(list).toContain('http_500');
 });
 
 test('Can list all error Objects', async() => {
@@ -35,7 +35,7 @@ test('Can list all error Objects', async() => {
 	var list = StandardError.listErrors();
 
 	// Test
-	expect(list).toContain(StandardError[500]);
+	expect(list).toContainEqual(StandardError['http_500']());
 });
 
 test.each`
@@ -75,7 +75,7 @@ test.each`
 test('Expanding StandardError object with blob of multiple new errors fails malformed errors individually', async() => {
 	// Setup
 	var data = [
-		{code: 500, domain: 'application', title: 'Test 1', message: '500 is already taken by the default StandardError object'},
+		{code: 'http_500', domain: 'application', title: 'Test 1', message: '500 is already taken by the default StandardError object'},
 		{code: 701, domain: undefined, title: 'Test 2', message: 'Error with undefined domain'},
 		{code: 702, domain: 'application', title: undefined, message: 'Error with undefined title'},
 		{code: 703, domain: 'application', title: 'Test 4', message: undefined},
@@ -89,9 +89,9 @@ test('Expanding StandardError object with blob of multiple new errors fails malf
 	expect(verification.passed).toEqual(false);
 
 	// Failed 500 and did not overwrite existing 500 error
-	expect(verification[500].passed).toEqual(false);
-	expect(verification[500].code).toEqual('Code already in use');
-	expect(StandardError[500]).not.toEqual(data.filter(error => error.code == 500)[0]);
+	expect(verification['http_500'].passed).toEqual(false);
+	expect(verification['http_500'].code).toEqual('Code already in use');
+	expect(StandardError['http_500']()).not.toEqual(data.filter(error => error.code == 'http_500')[0]);
 
 	// Failed 801 error
 	expect(verification[701].passed).toEqual(false);
@@ -109,7 +109,7 @@ test('Expanding StandardError object with blob of multiple new errors fails malf
 	expect(StandardError[703]).toEqual(undefined);
 
 	// Passed 804 error
-	expect(StandardError[704]).toEqual(data.filter(error => error.code == 704)[0]);
+	expect(StandardError[704]()).toEqual(data.filter(error => error.code == 704)[0]);
 });
 
 test('Can expand StandardError object with blob of multiple new errors with one call', async() => {
@@ -126,10 +126,10 @@ test('Can expand StandardError object with blob of multiple new errors with one 
 
 	// Test
 	expect(verification.passed).toEqual(true);
-	expect(StandardError[800]).toEqual(data.filter(error => error.code == 800)[0]);
-	expect(StandardError[801]).toEqual(data.filter(error => error.code == 801)[0]);
-	expect(StandardError[802]).toEqual(data.filter(error => error.code == 802)[0]);
-	expect(StandardError[803]).toEqual(data.filter(error => error.code == 803)[0]);
+	expect(StandardError[800]()).toEqual(data.filter(error => error.code == 800)[0]);
+	expect(StandardError[801]()).toEqual(data.filter(error => error.code == 801)[0]);
+	expect(StandardError[802]()).toEqual(data.filter(error => error.code == 802)[0]);
+	expect(StandardError[803]()).toEqual(data.filter(error => error.code == 803)[0]);
 });
 
 test('Can output all errors by domain as Object with codes as keys', async() => {
@@ -137,8 +137,8 @@ test('Can output all errors by domain as Object with codes as keys', async() => 
 	var map = StandardError.show('application');
 
 	// Test
-	expect(map[500]).toEqual(undefined);
-	expect(map[600]).toEqual(StandardError[600]);
+	expect(map['http_500']).toEqual(undefined);
+	expect(map[600]).toEqual(StandardError[600]());
 });
 
 test('Can list all error keys by domain', async() => {
@@ -146,7 +146,7 @@ test('Can list all error keys by domain', async() => {
 	var list = StandardError.listKeys('application');
 
 	// Test
-	expect(list).not.toContain('500');
+	expect(list).not.toContain('http_500');
 	expect(list).toContain('600');
 });
 
@@ -155,21 +155,21 @@ test('Can list all errors by domain as list of Objects', async() => {
 	var list = StandardError.listErrors('application');
 
 	// Test
-	expect(list).not.toContain(StandardError[500]);
-	expect(list).toContain(StandardError[600]);
+	expect(list).not.toContainEqual(StandardError['http_500']());
+	expect(list).toContainEqual(StandardError[600]());
 });
 
 test('Can remove errors by key from StandardError Object', async() => {
 	// Verify that 500 error exists
-	expect(StandardError[500]).not.toEqual(undefined);
-	expect(StandardError.listKeys()).toContain('500');
+	expect(StandardError['http_500']).not.toEqual(undefined);
+	expect(StandardError.listKeys()).toContain('http_500');
 
 	// Execute
-	StandardError.remove(500);
+	StandardError.remove('http_500');
 
 	// Test
-	expect(StandardError[500]).toEqual(undefined);
-	expect(StandardError.listKeys()).not.toContain('500');
+	expect(StandardError['http_500']).toEqual(undefined);
+	expect(StandardError.listKeys()).not.toContain('http_500');
 });
 
 test('Can remove errors by domain from StandardError Object', async() => {
@@ -183,4 +183,26 @@ test('Can remove errors by domain from StandardError Object', async() => {
 	// Test
 	expect(StandardError[600]).toEqual(undefined);
 	expect(StandardError.listKeys()).not.toContain('600');
+});
+
+test.each`
+	code          | details
+	${'http_502'} | ${'This error is not cool!'}
+	${'http_502'} | ${{requestingUser: 'myuser_name'}}
+	${'http_404'} | ${{query: 'name:bob tag:apple'}}
+	${'http_404'} | ${{query: 'liftoff',
+	                  time: 1517946300}}
+	${'http_501'} | ${{file: 'myFile.js',
+	                  line: 100,
+	                  errorData: 'Endpoint not implemented.'}}
+	${'http_404'} | ${12345}
+`('Can store extra details with each StandardError instance', ({code, details}) => {
+	// Execute
+	var myError = StandardError[code](details);
+
+	// Test
+	expect(myError).toHaveProperty('details');
+	expect(myError.details).toEqual(details);
+	expect(myError).toEqual({...StandardError[code](), details: details});
+	expect(myError.message).toEqual(StandardError[code]().message);
 });


### PR DESCRIPTION
This update changes the way that new StandardErrors are stored and referenced. Creating a new instance of an existing error is done by calling the function of StandardError that has the name of the error code. This function can take an optional argument that is an object that will be stored under the `details` field of the new error instance.

```javascript
StandardError.add({ code: 'myError', title: 'My New Error!', message: 'an error occurred' });

let myInstance = StandardError.myError();
let instanceWithDetails = StandardError.myError({ name: 'Trevor', username: 'trevorrecker' });
```

In the above, the data objects look like the following:

```javascript
myInstance = {
    code: 'myError',
    title: 'My New Error!',
    message: 'an error occurred'
}

instanceWithDetails = {
    code: 'myError',
    title: 'My New Error!',
    message: 'an error occurred',
    details: {
        name: 'Trevor',
        username: 'trevorrecker'
    }
}
```

## Changes

- Updated StandardError to store errors as functions that create unique instances of the error when called.
- Added the ability to include extra details specific to a single instance of a StandardError by passing an object to the creation function.
- Updated the HttpCodes definition to be compatible with `StandardError.add`
- Updated HttpCodes keys to start with `http_`
- Added test cases for storing additional data in a StandardError
- Updated existing test cases to account for the new instantiation process of errors
- Updated existing test cases to account for the new naming scheme of http errors