### PR TITLE
Add global extraProp properties, bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,29 @@ try {
 }
 ```
 
+You can add a "*" key to `extraProps` to define any properties that should exist on _all instances_ of your StandardError Errors. This can be useful to add some domain-specific details to an otherwise generic-seeming Error name, such as specifying the service that the Error was created for.
+
+```js
+import { createError } from '@unplgtc/standard-error';
+
+const ValidationError = createError({
+	name: 'ValidationError',
+	message: 'Request failed validation in ``service``'
+	extraProps: {
+		'*': { service: 'apiService' }
+	}
+});
+
+try {
+	throw new ValidationError();
+
+} catch (err) {
+	console.log(err.message); // Request failed validation in apiService
+	console.log(err.name); // ValidationError
+	console.log(err.service); // apiService
+}
+```
+
 ## Removing values from the StandardError object
 
 If you need to remove the built-in HttpError object in order to create your own custom version, you can do so using the `removeError()` function:

--- a/src/StandardError.js
+++ b/src/StandardError.js
@@ -29,7 +29,7 @@ function createError({ name, message, properties, extraProps }) {
 	return Errors[name] = extendStandardError({ name, message, properties, extraProps });
 }
 
-function extendStandardError({ name, message, properties, extraProps }) {
+function extendStandardError({ name, message, properties = [], extraProps }) {
 	return (class extends StandardError {
 		constructor(...args) {
 			// If more args passed than props, assume final arg is the `info` prop
@@ -43,6 +43,10 @@ function extendStandardError({ name, message, properties, extraProps }) {
 				if (matchedProps = extraProps?.[properties[i]]?.[args[i]]) {
 					Object.assign(this, matchedProps);
 				}
+			}
+
+			if (extraProps?.['*']) {
+				Object.assign(this, extraProps['*']);
 			}
 
 			this.message = message.split('``')

--- a/test/StandardError.test.js
+++ b/test/StandardError.test.js
@@ -88,3 +88,62 @@ test('Can create multiple StandardError Errors at once', async() => {
 	removeError('TestError');
 	removeError('OtherTestError');
 });
+
+test('Can create and throw a StandardError without properties', async() => {
+	// Setup
+	const TestError = createError({
+		name: 'TestError',
+		message: 'Testing'
+	});
+
+	// Execute
+	let err;
+	try {
+		throw new TestError('testInfo');
+
+	} catch (e) {
+		err = e;
+	}
+
+	// Test
+	expect(err.name).toEqual('TestError');
+	expect(err.message).toEqual('Testing');
+	expect(err.stack).not.toBe(undefined);
+	expect(err.info).toEqual('testInfo');
+	expect(err instanceof Error).toBe(true);
+	expect(err instanceof StandardError).toBe(true);
+	expect(err instanceof TestError).toBe(true);
+
+	// Cleanup
+	removeError('TestError');
+});
+
+test('The "*" key on extraProps places the props on all instances', async() => {
+	// Setup
+	const TestError = createError({
+		name: 'TestError',
+		message: 'Testing ``testProp``',
+		extraProps: { '*':  { testProp: 'star' }}
+	});
+
+	// Execute
+	let err;
+	try {
+		throw new TestError('testInfo');
+
+	} catch (e) {
+		err = e;
+	}
+
+	// Test
+	expect(err.name).toEqual('TestError');
+	expect(err.message).toEqual('Testing star');
+	expect(err.testProp).toEqual('star');
+	expect(err.info).toEqual('testInfo');
+	expect(err instanceof Error).toBe(true);
+	expect(err instanceof StandardError).toBe(true);
+	expect(err instanceof TestError).toBe(true);
+
+	// Cleanup
+	removeError('TestError');
+});


### PR DESCRIPTION
- Added ability to define a '*' key in `extraProps` which will apply its properties to all instances of a StandardError.
- Bugfix for an error that was being thrown when `properties` was undefined in a call to `createError()`.